### PR TITLE
Add component test

### DIFF
--- a/src/classmentors/components/ace/2015-ace-view.html
+++ b/src/classmentors/components/ace/2015-ace-view.html
@@ -4,15 +4,15 @@
 		<p>Click here to register and participate in the online portions of the <a href="http://www.classmentors.com/#/events/-Jqh4lFKnAQ3ACi3Crk6">junior</a></p>
 		or <a href="http://www.classmentors.com/#/events/-Jqh51g1CR4E00gg3mFl">senior</a> categories. You will need to login with a Google ID and the click on the "Join" button. 
 		<p>There will be lucky draw prizes for online participants who do not qualify to attend the live event. Online qualfication will end on August 26th at 12pm.</p>
-		<p><b>{{ctrl.stats.total_participants}}</b> students have registered so far.</p>
-		<p><b>{{ctrl.stats.total_schools}}</b> schools are participating.</p>
+		<p><b>{{$ctrl.stats.total_participants}}</b> students have registered so far.</p>
+		<p><b>{{$ctrl.stats.total_schools}}</b> schools are participating.</p>
 		<p>If you see a school missing in the rankings below, please encoruage them to participate.</p>
 		<p>You can visit the <a href="http://www.infocommtalent.sg/nic4.aspx">IDA website</a> for more details or visit the <a href="https://www.facebook.com/aceofcoders">Ace of Coders Facebook page</a> to leave comments, questions, and join the conversation.</p>
 	</md-content>
    
 	<md-toolbar md-scroll-shrink>
 		<div class="md-toolbar-tools">
-			<h3><span>{{ctrl.stats.junior_schools}} Participating Junior Category Schools</span></h3>
+			<h3><span>{{$ctrl.stats.junior_schools}} Participating Junior Category Schools</span></h3>
 		</div>
 	</md-toolbar>
 	<md-content class="md-padding">
@@ -24,7 +24,7 @@
 				<th>School</th>
 				<th>Second ranked student from school</th> 
 			</tr>
-			<tr ng-repeat="school in ctrl.stats.junior_ranking" bgcolor="{{$index==9?'lightgreen':'white'}}">
+			<tr ng-repeat="school in $ctrl.stats.junior_ranking" bgcolor="{{$index==9?'lightgreen':'white'}}">
 				<td>{{$index+1}}</td>				
 				<td>{{school.total}}</td>
 				<td>{{school.school}}</td>
@@ -37,7 +37,7 @@
 
 	<md-toolbar md-scroll-shrink>
 		<div class="md-toolbar-tools">
-			<h3><span>{{ctrl.stats.senior_ranking.length}} Participating Senior Category Schools</span></h3>
+			<h3><span>{{$ctrl.stats.senior_ranking.length}} Participating Senior Category Schools</span></h3>
 		</div>
 	</md-toolbar>
 	<md-content class="md-padding">
@@ -49,7 +49,7 @@
 				<th>School</th>
 				<th>Second ranked student from school</th> 
 			</tr>
-			<tr ng-repeat="school in ctrl.stats.senior_ranking"  bgcolor="{{$index==9?'lightgreen':'white'}}">
+			<tr ng-repeat="school in $ctrl.stats.senior_ranking"  bgcolor="{{$index==9?'lightgreen':'white'}}">
 				<td>{{$index+1}}</td>
 				<td>{{school.total}}</td>
 				<td>{{school.school}}</td>
@@ -70,7 +70,7 @@
 				<th>Registered Students</th> 
 				<th>School</th>
 			</tr>
-			<tr ng-repeat="school in ctrl.stats.juniorSchoolRanking | limitTo:5">
+			<tr ng-repeat="school in $ctrl.stats.juniorSchoolRanking | limitTo:5">
 				<td>{{school.total}}</td>
 				<td>{{school.school}}</td>				
 			</tr>
@@ -88,7 +88,7 @@
 				<th>Registered Students</th> 
 				<th>School</th>
 			</tr>
-			<tr ng-repeat="school in ctrl.stats.seniorSchoolRanking | limitTo:5">
+			<tr ng-repeat="school in $ctrl.stats.seniorSchoolRanking | limitTo:5">
 				<td>{{school.total}}</td>
 				<td>{{school.school}}</td>				
 			</tr>

--- a/src/classmentors/components/ace/ace-view.html
+++ b/src/classmentors/components/ace/ace-view.html
@@ -4,8 +4,8 @@
 		<p>Click here to register and participate in the online portions of the <a href="http://www.classmentors.com/#/events/-Jqh4lFKnAQ3ACi3Crk6">junior</a> 
 		or <a href="http://www.classmentors.com/#/events/-Jqh51g1CR4E00gg3mFl">senior</a> categories. You will need to login with a Google ID and the click on the "Join" button. 
 		<p>There will be lucky draw prizes for online participants who do not qualify to attend the live event. Online qualfication will end on August 26th at 12pm.</p>
-		<p><b>{{ctrl.stats.total_participants}}</b> students have registered so far.</p>
-		<p><b>{{ctrl.stats.total_schools}}</b> schools are participating.</p>
+		<p><b>{{$ctrl.stats.total_participants}}</b> students have registered so far.</p>
+		<p><b>{{$ctrl.stats.total_schools}}</b> schools are participating.</p>
 		<p>If you see a school missing in the rankings below, please encoruage them to participate.</p>
 		<p>You can visit the <a href="http://www.infocommtalent.sg/nic4.aspx">IDA website</a> for more details or visit the <a href="https://www.facebook.com/aceofcoders">Ace of Coders Facebook page</a> to leave comments, questions, and join the conversation.</p>
 		
@@ -13,7 +13,7 @@
    
 	<md-toolbar md-scroll-shrink>
 		<div class="md-toolbar-tools">
-			<h3><span>{{ctrl.stats.junior_schools}} Participating Junior Category Schools</span></h3>
+			<h3><span>{{$ctrl.stats.junior_schools}} Participating Junior Category Schools</span></h3>
 		</div>
 	</md-toolbar>
 	<md-content class="md-padding">
@@ -25,7 +25,7 @@
 				<th>School</th>
 				<th>Second ranked student from school</th> 
 			</tr>
-			<tr ng-repeat="school in ctrl.stats.junior_ranking" bgcolor="{{$index==9?'lightgreen':'white'}}">
+			<tr ng-repeat="school in $ctrl.stats.junior_ranking" bgcolor="{{$index==9?'lightgreen':'white'}}">
 				<td>{{$index+1}}</td>				
 				<td>{{school.total}}</td>
 				<td>{{school.school}}</td>
@@ -38,7 +38,7 @@
 
 	<md-toolbar md-scroll-shrink>
 		<div class="md-toolbar-tools">
-			<h3><span>{{ctrl.stats.senior_ranking.length}} Participating Senior Category Schools</span></h3>
+			<h3><span>{{$ctrl.stats.senior_ranking.length}} Participating Senior Category Schools</span></h3>
 		</div>
 	</md-toolbar>
 	<md-content class="md-padding">
@@ -50,7 +50,7 @@
 				<th>School</th>
 				<th>Second ranked student from school</th> 
 			</tr>
-			<tr ng-repeat="school in ctrl.stats.senior_ranking"  bgcolor="{{$index==9?'lightgreen':'white'}}">
+			<tr ng-repeat="school in $ctrl.stats.senior_ranking"  bgcolor="{{$index==9?'lightgreen':'white'}}">
 				<td>{{$index+1}}</td>
 				<td>{{school.total}}</td>
 				<td>{{school.school}}</td>
@@ -71,7 +71,7 @@
 				<th>Registered Students</th> 
 				<th>School</th>
 			</tr>
-			<tr ng-repeat="school in ctrl.stats.juniorSchoolRanking | limitTo:5">
+			<tr ng-repeat="school in $ctrl.stats.juniorSchoolRanking | limitTo:5">
 				<td>{{school.total}}</td>
 				<td>{{school.school}}</td>				
 			</tr>
@@ -89,7 +89,7 @@
 				<th>Registered Students</th> 
 				<th>School</th>
 			</tr>
-			<tr ng-repeat="school in ctrl.stats.seniorSchoolRanking | limitTo:5">
+			<tr ng-repeat="school in $ctrl.stats.seniorSchoolRanking | limitTo:5">
 				<td>{{school.total}}</td>
 				<td>{{school.school}}</td>				
 			</tr>

--- a/src/classmentors/components/ace/ace.js
+++ b/src/classmentors/components/ace/ace.js
@@ -1,64 +1,77 @@
-'use strict';
-
-import {classMentors} from '../../module.js';
-
-import tmpl from './2015-ace-view.html!text';
-
-classMentors.config([
-  '$routeProvider',
-  'routes',
-  function($routeProvider, routes) {
-    $routeProvider.
-
-    when(routes.aceOfCoders, {
-      template: tmpl,
-      controller: 'ClmAceOfCodersCtrl',
-      controllerAs: 'ctrl',
-      resolve: {
-        'initialData': [
-          'clmAceOfCodersCtrlInitialData',
-          function(clmAceOfCodersCtrlInitialData) {
-            return clmAceOfCodersCtrlInitialData();
-          }
-        ]
-      }
-    })
-
-    ;
-
-  }
-]);
+/**
+ * classmentors/components/ace/ace.js - Define the ace component.
+ */
+import template from './2015-ace-view.html!text';
 
 /**
- * Use to resolve `initialData` of `ClmAceOfCodersCtrl`.
+ * Update navBar with a title and no action.
  *
+ * @param {spfNavBarService} spfNavBarService
  */
-classMentors.factory('clmAceOfCodersCtrlInitialData', [
-  '$q',
-  function clmAceOfCodersCtrlInitialDataFactory($q) {
-    return function clmAceOfCodersCtrlInitialData() {
-      return $q.all({});
-    };
-  }
-]);
+function AceController(spfNavBarService) {
+  spfNavBarService.update('Ace of Coders');
+}
+
+AceController.$inject = ['spfNavBarService'];
 
 /**
- * ClmAceOfCodersCtrl
+ * ace component.
  *
+ * @type {Object}
  */
-classMentors.controller('ClmAceOfCodersCtrl', [
-  'initialData',
-  'spfNavBarService',
-  '$http',
-  function ClmAceOfCodersCtrl(initialData, spfNavBarService, $http) {
-    spfNavBarService.update('Ace of Coders');
-    this.stats = {};
-    var parent = this;
-    $http.get('https://dl.dropboxusercontent.com/u/4972572/ace_of_coders_stats.json').
-      then(function(response) {
-        parent.stats = response.data;
-      }
-      //, function(response) { // called asynchronously if an error occurs}
-      );
-  }
-]);
+export const component = {
+  template,
+  bindings: {
+    // binds $ctrl.stats to the value of the stats attribute.
+    stats: '<'
+  },
+  controller: AceController
+};
+
+/**
+ * Configure ace of coders route
+ *
+ * @param  {$routeProvider} $routeProvider
+ * @param  {Object}         routes
+ */
+export function configRoute($routeProvider, routes) {
+  $routeProvider.when(routes.aceOfCoders, {
+    template: '<ace stats="$resolve.stats"></ace>',
+    resolve: {
+      // ngRoute will wait for the promise aceStats to resolve before assigning
+      // it to $resolve.stats. Once, it's resolved, the template will be run.
+      stats: ['aceStats', aceStats => aceStats()]
+    }
+  });
+}
+
+configRoute.$inject = ['$routeProvider', 'routes'];
+
+export const ACE_STATS_URL = 'https://dl.dropboxusercontent.com/u/4972572/ace_of_coders_stats.json';
+
+/**
+ * aceStats factory
+ *
+ * return the aceStats function.
+ *
+ * @param  {$http}    $http
+ * @return {function}
+ */
+export function factory($http, aceStatsUrl) {
+
+  /**
+   * aceStats service
+   *
+   * Resolve to the Ace stats
+   *
+   * @return {Promise}
+   */
+  return function aceStats() {
+    return $http.get(aceStatsUrl).then(
+      response => response.data
+    );
+  };
+}
+
+factory.$inject = ['$http', 'aceStatsUrl'];
+

--- a/src/classmentors/components/ace/ace.specs.js
+++ b/src/classmentors/components/ace/ace.specs.js
@@ -1,0 +1,69 @@
+import {expect} from 'chai';
+import sinon from 'sinon';
+
+import tmpl from './2015-ace-view.html!text';
+import {component, factory, ACE_STATS_URL} from './ace.js';
+
+describe('ace component', function() {
+
+  it('should set the template', function() {
+    expect(component.template).to.equal(tmpl);
+  });
+
+  describe('controller', function() {
+    let navBarService;
+
+    beforeEach(function() {
+      navBarService = {
+        update: sinon.spy()
+      };
+    });
+
+    it('should update the navbar title', function() {
+      new component.controller(navBarService);
+
+      expect(navBarService.update).to.have.been.calledOnce;
+      expect(navBarService.update).to.have.been.calledWithExactly(sinon.match.string);
+    });
+
+  });
+
+});
+
+describe('aceStatsUrl constant', function() {
+
+  it('should be set', function() {
+    expect(ACE_STATS_URL).to.be.ok;
+  });
+
+});
+
+describe('aceStats service', function() {
+  const aceStatsUrl = 'http://ace.stats/';
+  let aceStats, http;
+
+  beforeEach(function() {
+    http = {
+      get: sinon.stub().returns(Promise.reject())
+    };
+    aceStats = factory(http, aceStatsUrl);
+  });
+
+  it('should fetch the ace stats', function() {
+    aceStats();
+    expect(http.get).to.have.been.calledOnce;
+    expect(http.get).to.have.been.calledWithExactly(aceStatsUrl);
+  });
+
+  it('should resolve to the response data', function() {
+    const resp = {data: {some: 'stats'}};
+
+    http.get.returns(Promise.resolve(resp));
+
+    // By returning a promise, the test runner knows the test asynchronous
+    // and will wait for it resolve.
+    return aceStats().then(
+      data => expect(data).to.equal(resp.data)
+    );
+  });
+});

--- a/src/classmentors/components/classmentors/classmentors.js
+++ b/src/classmentors/components/classmentors/classmentors.js
@@ -1,9 +1,8 @@
 'use strict';
 
-import {classMentors} from '../../module.js';
 import tmpl from './classmentors-view.html!text';
 import './classmentors.css!';
 
-classMentors.component('classmentors', {
+export const component = {
   template: tmpl
-});
+};

--- a/src/classmentors/components/classmentors/classmentors.specs.js
+++ b/src/classmentors/components/classmentors/classmentors.specs.js
@@ -1,0 +1,12 @@
+import {expect} from 'chai';
+
+import tmpl from './classmentors-view.html!text';
+import {component} from './classmentors.js';
+
+describe('classmentors component', function() {
+
+  it('should set the template', function() {
+    expect(component.template).to.equal(tmpl);
+  });
+
+});

--- a/src/classmentors/components/index.js
+++ b/src/classmentors/components/index.js
@@ -1,6 +1,16 @@
 'use strict';
 
-import './ace/ace.js';
-import './classmentors/classmentors.js';
+import {classMentors} from 'classmentors/module.js';
+
+import * as app from './classmentors/classmentors.js';
+import * as ace from './ace/ace.js';
 import './events/events.js';
 import './profiles/profiles.js';
+
+classMentors.component('classmentors', app.component);
+classMentors.component('ace', ace.component);
+
+classMentors.constant('aceStatsUrl', ace.ACE_STATS_URL);
+classMentors.factory('aceStats', ace.factory);
+
+classMentors.config(ace.configRoute);

--- a/src/tests.js
+++ b/src/tests.js
@@ -1,9 +1,7 @@
-(function() {
-  'use strict';
-  describe('Configuration', function() {
-    it('should run a simple test', function() {
-      //Uncommenting expect will cause an error.
-      //expect(1).toBe(1);
-    });
-  });
-})();
+import * as chai from 'chai';
+import sinonChai from 'sinon-chai';
+
+chai.use(sinonChai);
+
+import 'classmentors/components/classmentors/classmentors.specs.js';
+import 'classmentors/components/ace/ace.specs.js';


### PR DESCRIPTION
Add tests for the classmentors component and for the ace of coders component.

I picked ace of coder because it’s very small. I converted it to an Angular 1.5 component and moved fetching the stats to a component attribute resolved during routing.

Fetching the stats is now a service that return a promise: it’s easy to test on its own. The url to fetch is an angular constant; we do not need to hard code the url to fetch in the test (maybe it doesn’t need to be an angular constant, just an exported value).

TODO: add tests for other components
