### PR TITLE
Cohort bug fix

### DIFF
--- a/src/classmentors/components/ace/ace-view.html
+++ b/src/classmentors/components/ace/ace-view.html
@@ -45,7 +45,6 @@ ClassMentors Team<br>
 				<td><a href="{{school.eventURL}}">{{school.school}}</a></td>
 				<td ng-if="school.name !== 'no second student'"></td>
 				<td></td>
-				<!--<td ng-if="school.name == 'no second student'"><span style="font-style: italic; color: grey;">No second student</span></td>-->
 			</tr>
 
 	    </table>

--- a/src/classmentors/components/cohorts/cohorts-view-cohort-ranking-page.html
+++ b/src/classmentors/components/cohorts/cohorts-view-cohort-ranking-page.html
@@ -24,7 +24,7 @@
                         {{ event.rank }}
                     </th>
                     <td>{{ event.participants.length }}</td>
-                    <td>{{ event.title }}</td>
+                    <td><a href="#{{ 'oneEvent' | urlFor: {eventId: event.id} }}">{{ event.title }}</a></td>
                 </tr>
             </tbody>
         </table>

--- a/src/classmentors/components/cohorts/cohorts-view-cohort.html
+++ b/src/classmentors/components/cohorts/cohorts-view-cohort.html
@@ -3,12 +3,21 @@
           rel="stylesheet">
     <md-tabs md-dynamic-height="true" md-border-bottom="true">
 
+        <md-tab label="Ranking">
+            <md-content layout-padding>
+                <clm-cohorts-ranking-page
+                        cohort="ctrl.cohort"
+                        profile="ctrl.profile">
+                </clm-cohorts-ranking-page>
+            </md-content>
+        </md-tab>
+
         <md-tab label="Announcements">
             <md-content layout-padding>
                 Events within this cohort:
                 <md-select flex ng-model="ctrl.selectedEvent" name="selectEvent" placeholder="View cohort events">
                     <md-option disabled ng-value="event" ng-repeat="event in ctrl.cohort.events">
-                        {{ctrl.events[event].title}}
+                        <a href="#{{ 'oneEvent' | urlFor: {eventId: event} }}">{{ ctrl.events[event].title }}</a>
                     </md-option>
                 </md-select>
                 Go to my event:<br>
@@ -45,15 +54,6 @@
                         </md-card-content>
                     </md-card>
                 </md-content>
-            </md-content>
-        </md-tab>
-
-        <md-tab label="Ranking">
-            <md-content layout-padding>
-                <clm-cohorts-ranking-page
-                        cohort="ctrl.cohort"
-                        profile="ctrl.profile">
-                </clm-cohorts-ranking-page>
             </md-content>
         </md-tab>
 

--- a/src/classmentors/components/cohorts/cohorts.js
+++ b/src/classmentors/components/cohorts/cohorts.js
@@ -320,51 +320,9 @@ function viewCohortCtrlInitialData($q, $route, spfAuth, spfAuthData, clmDataStor
         profile: profilePromise,
         cohort: cohortPromise,
         canView: canviewPromise,
-        announcements: canviewPromise.then(function (canView) {
-            if(canView) {
-                return clmDataStore.cohorts.getAnnouncements(cohortId);
-            }
-        }),
-        events: canviewPromise.then(function (canView) {
-            if(canView) {
-                return clmDataStore.events.listAll();
-            }
-        }),
-        joinedEvents: canviewPromise.then(function (canView) {
-            if(canView) {
-                return clmDataStore.events.listJoinedEventsObj();
-            }
-        })
-        // events: canviewPromise.then(function(canView) {
-        //     if(canView) {
-        //         return clmDataStore.cohorts.getEvents(cohortId);
-        //     }
-        // }),
-        // tasks: canviewPromise.then(function(canView) {
-        //     if (canView) {
-        //         return clmDataStore.events.getTasks(eventId);
-        //     }
-        // }),
-        // participants: canviewPromise.then(function(canView) {
-        //     if (canView) {
-        //         return clmDataStore.events.participants(eventId);
-        //     }
-        // }),
-        // progress: canviewPromise.then(function(canView) {
-        //     if (canView) {
-        //         return clmDataStore.events.getProgress(eventId);
-        //     }
-        // }),
-        // solutions: canviewPromise.then(function(canView) {
-        //     if (canView) {
-        //         return clmDataStore.events.getSolutions(eventId);
-        //     }
-        // }),
-        // scores: canviewPromise.then(function(canView) {
-        //     if (canView) {
-        //         return clmDataStore.events.getScores(eventId);
-        //     }
-        // })
+        announcements: clmDataStore.cohorts.getAnnouncements(cohortId),
+        events: clmDataStore.events.listAll(),
+        joinedEvents: clmDataStore.events.listJoinedEventsObj()
     });
 }
 viewCohortCtrlInitialData.$inject = [
@@ -890,12 +848,18 @@ function ClmCohortRankPageCtrl($q, $scope, $log, spfFirebase, clmDataStore, clmP
                 }).then(function(data) {
                     var result = data;
                     oneEventData.participants = result;
+                }).catch(function (err) {
+                    // prevent events with no participants from breaking the code by initialising their participant array to an empty one.
+                    oneEventData.participants = [];
+                    $log.error(err);
+                    return err;
                 }).then(function () {
                     spfFirebase.loadedObj(['classMentors/events', event]).then(function(promise) {
                         return promise;
                     }).then(function(data) {
                         var result = data;
                         oneEventData.title = result.title;
+                        oneEventData.id = result.$id;
                         self.cohortEventData.push(oneEventData);
                         iter++;
                         loopDBEvents();
@@ -914,10 +878,10 @@ function ClmCohortRankPageCtrl($q, $scope, $log, spfFirebase, clmDataStore, clmP
                         self.cohortEventData[i].rank = rank;
                     }
                 }
-                if(self.cohortEventData[self.cohortEventData.length-1].participants.length < self.cohortEventData[self.cohortEventData.length-2].participants.length) {
-                    rank++;
+                if(self.cohortEventData[self.cohortEventData.length-1].participants.length <= self.cohortEventData[self.cohortEventData.length-2].participants.length) {
                     self.cohortEventData[self.cohortEventData.length-1].rank = rank;
                 } else {
+                    rank--;
                     self.cohortEventData[self.cohortEventData.length-1].rank = rank;
                 }
             }

--- a/src/classmentors/components/events/events.js
+++ b/src/classmentors/components/events/events.js
@@ -739,7 +739,7 @@ function EditEventCtrl(initialData, spfNavBarService, urlFor, spfAlert, clmDataS
   this.event = initialData.event;
   this.tasks = initialData.tasks;
   this.showingAssistants = false;
-  this.showingTasks = false;
+  this.showingTasks = true;
   this.assistants = initialData.assistants;
   this.newPassword = '';
   this.isOwner = false;


### PR DESCRIPTION
Fixed cohort bug in for events with no participants and hence no path in firebase for eventParticipants/eventTask. 

Fixed access control for students viewing cohorts. (Issue was in setting of canViewPromise parameter for non-admin functions)

Set oneCohort default tab to ranking, enabled navigation to events from ranking table.

Set editing events page to default show all editable tasks. This view may still be collaped if the user wishes.
