### PR TITLE
Participant joined time

### DIFF
--- a/security_rules/security-rules.json
+++ b/security_rules/security-rules.json
@@ -185,29 +185,25 @@
       "eventParticipants": {
         "$eventId": {
           "$publicId": {
-            ".validate": "newData.hasChildren(['user'])",
-            ".write": "newData.exists() === false && auth !== null && root.child('auth/publicIds').child($publicId).val() === auth.uid && root.child('classMentors/userProfiles').child($publicId).child('joinedEvents').child($eventId).exists() === false",
+            ".validate": "newData.hasChildren(['user', 'joinedAt']) || (data.exists() && data.hasChildren(['joinedAt']) == false && newData.hasChildren(['user']))",
+            ".write": "auth !== null && root.child('auth/publicIds').child($publicId).val() === auth.uid && (newData.exists() == false || root.child('classMentors/eventApplications').child($eventId).child(auth.uid).exists()) && (newData.exists() || root.child('classMentors/userProfiles').child($publicId).child('joinedEvents').child($eventId).exists() === false)",
             "user": {
               ".validate": "newData.hasChildren(['displayName', 'gravatar'])",
-              ".write": "auth !== null && root.child('auth/publicIds').child($publicId).val() === auth.uid && root.child('classMentors/eventApplications').child($eventId).child(auth.uid).exists()",
-              "displayName": {
-                ".validate": "newData.isString() && newData.val().length >= 3"
-              },
-              "gravatar": {
-                ".validate": "newData.isString() && newData.val().matches(/(https?\\:)?\\/\\/.+/)"
-              },
               "school": {
                 ".validate": "newData.hasChildren(['name', 'type'])",
-                "iconUrl": {
-                  ".validate": "newData.isString()"
-                },
-                "name": {
-                  ".validate": "newData.isString()"
-                },
-                "type": {
-                  ".validate": "newData.isString()"
+                "$key": {
+                  ".validate": "($key == 'name' || $key == 'type' || $key == 'id' || $key == 'iconUrl') && newData.val() == root.child('auth/users').child(auth.uid).child('school').child($key).val()"
                 }
+              },
+              "$key": {
+                ".validate": "($key == 'displayName' || $key == 'gravatar') && newData.val() == root.child('auth/users').child(auth.uid).child($key).val()"
               }
+            },
+            "joinedAt": {
+              ".validate": "newData.val() == data.val() || (data.exists() == false && newData.val() == now)"
+            },
+            "$other": {
+              ".validate": "false"
             }
           },
           ".read": "auth !== null && (\n  root.child('classMentors/eventApplications/').child($eventId).child(auth.uid).exists()\n  || root.child('classMentors/events').child($eventId).child('owner/publicId').val() === root.child('auth/users').child(auth.uid).child('publicId').val()\n  || root.child('classMentors/admins').child(auth.uid).val() === true || true)",

--- a/security_rules/test/index.specs.js
+++ b/security_rules/test/index.specs.js
@@ -7,3 +7,4 @@ chai.use(targaryen.chai);
 
 require('./security-rules.specs.js');
 require('./auth.specs.js');
+require('./events.specs.js');

--- a/security_rules/test/utils.js
+++ b/security_rules/test/utils.js
@@ -5,6 +5,15 @@ var rules = require('../security-rules.json');
 var targaryen = require('@dinoboff/targaryen');
 var deepAssign = require('deep-assign');
 
+const timestamp = () => ({'.sv': 'timestamp'});
+
+before(function() {
+  targaryen.setDebug(true);
+  targaryen.setFirebaseRules(rules);
+});
+
+exports.timestamp = timestamp;
+
 /**
  * Set targaryen's firebase data by complining singpath-play-export data
  * with the patch.
@@ -34,7 +43,43 @@ exports.setFirebaseData = function(patch) {
   targaryen.setFirebaseData(data);
 };
 
-before(function() {
-  targaryen.setDebug(true);
-  targaryen.setFirebaseRules(rules);
-});
+exports.bob = function() {
+  const uid = 'github:808';
+  const publicId = 'bob';
+  const firebaseAuth = {
+    uid,
+    id: 808,
+    provider: 'github'
+  };
+  const user = {
+    displayName: 'bob',
+    gravatar: '//www.gravatar.com/avatar/some-hash'
+  };
+  const userData = {
+    displayName: user.displayName,
+    email: 'bob@example.com',
+    fullName: 'Bob Smith',
+    gravatar: user.gravatar,
+    id: uid,
+    publicId: publicId,
+    yearOfBirth: 1990,
+    createdAt: timestamp()
+  };
+  const auth = {
+    publicIds: {[publicId]: uid},
+    usedPublicIds: {[publicId]: true},
+    users: {[uid]: userData}
+  };
+  const profile = {
+    user: {
+      displayName: user.displayName,
+      gravatar: user.gravatar,
+      isAdmin: false,
+      isPremium: false,
+      yearOfBirth: userData.yearOfBirth
+    }
+  };
+  const userProfiles = {[publicId]: profile};
+
+  return {uid, publicId, firebaseAuth, user, userData, auth, profile, userProfiles};
+};

--- a/src/classmentors/services.js
+++ b/src/classmentors/services.js
@@ -961,7 +961,7 @@ export function clmDataStoreFactory(
           paths = {
             hashOptions: ['classMentors/eventPasswords', eventId, 'options'],
             application: ['classMentors/eventApplications', eventId, spfAuth.user.uid],
-            participation: ['classMentors/eventParticipants', eventId, authData.publicId, 'user'],
+            participation: ['classMentors/eventParticipants', eventId, authData.publicId],
             profile: ['classMentors/userProfiles', authData.publicId, 'joinedEvents', eventId]
           };
         }).then(function() {
@@ -971,9 +971,12 @@ export function clmDataStoreFactory(
           return spfFirebase.set(paths.application, hash);
         }).then(function() {
           return spfFirebase.set(paths.participation, {
-            displayName: authData.displayName,
-            gravatar: authData.gravatar,
-            school: spfFirebase.cleanObj(authData.school) || null
+            user: {
+              displayName: authData.displayName,
+              gravatar: authData.gravatar,
+              school: spfFirebase.cleanObj(authData.school) || null
+            },
+            joinedAt: {'.sv': 'timestamp'}
           });
         }).then(function() {
           return spfFirebase.set(paths.profile, {


### PR DESCRIPTION
Fix #78

add classMentors/eventParticpants/$eventId/$publicId/joinedAt to record when a user joined an event.

The rules allow a user to update a old participation without joinedAt record, but new participation will require a timestamp.

When the rules are updated, the old client will not let event joined.
