### PR TITLE
Cohort Assistants (Raw)

### DIFF
--- a/src/classmentors/components/cohorts/cohorts-view-cohort.html
+++ b/src/classmentors/components/cohorts/cohorts-view-cohort.html
@@ -68,9 +68,13 @@
         </md-tab>
         <md-tab label="Manage" ng-if="ctrl.isOwner">
             <md-content layout-padding>
-                <md-button ng-click="ctrl.selectedAction='dupChallenges'">
+                <md-button ng-click="ctrl.selectedAction='dupChallenges'" ng-class="{false:'md-raised', true:'md-raised md-primary'}[ctrl.selectedAction=='dupChallenges']">
                     Duplicate event challenges
                     <md-icon class="material-icons">leak_remove</md-icon>
+                </md-button>
+                <md-button ng-click="ctrl.startManageAsst()" ng-class="{false:'md-raised', true:'md-raised md-primary'}[ctrl.selectedAction=='cohortAsst']">
+                    Manage assistants
+                    <md-icon class="material-icons">supervisor_account</md-icon>
                 </md-button>
                 <div ng-if="ctrl.selectedAction=='dupChallenges'">
                     Move events:<br>
@@ -115,6 +119,25 @@
                         <md-button class="md-raised md-primary" ng-if="ctrl.selectedEvents" ng-click="ctrl.duplicateChallenges()">
                             Duplicate
                         </md-button>
+                    </div>
+                </div>
+                <div ng-if="ctrl.selectedAction=='cohortAsst'">
+                    <md-input-container>
+                        <label for="findUser">Find a User</label>
+                        <input name="findUser" type="text" id="findUser" ng-model="ctrl.userQuery"/>
+                    </md-input-container>
+                    <md-button class="md-raised md-primary" ng-click="ctrl.findUsers()">
+                        Find User
+                    </md-button>
+                    <div ng-if="ctrl.foundUsers">
+                        Found {{ctrl.foundUsers.length}} user(s)
+                        <md-list>
+                            <md-list-item ng-repeat="user in ctrl.foundUsers">
+                                <span flex>{{user.user.displayName}}</span>
+                                <md-button class="md-raised md-primary" ng-click="ctrl.assignCohortAssistant(user)">Make Cohort Assistant</md-button>
+                            </md-list-item>
+                        </md-list>
+                        <md-divider></md-divider>
                     </div>
                 </div>
             </md-content>

--- a/src/classmentors/components/cohorts/cohorts.js
+++ b/src/classmentors/components/cohorts/cohorts.js
@@ -330,7 +330,7 @@ viewCohortCtrlInitialData.$inject = [
 
 function ViewCohortCtrl(
     $log, $scope, initialData, $document, $mdDialog, $route, $firebaseObject,
-    spfAlert, urlFor, firebaseApp, spfAuthData, spfNavBarService, clmDataStore
+    spfAlert, urlFor, firebaseApp, spfAuthData, spfNavBarService, clmDataStore, $firebaseArray
 ) {
     var self = this;
     var db = firebaseApp.database();
@@ -458,6 +458,38 @@ function ViewCohortCtrl(
         }
     };
 
+    this.userQuery = '';
+    this.foundUsers = null;
+
+    this.startManageAsst = function () {
+        self.selectedAction = 'cohortAsst';
+    };
+    this.findUsers = function () {
+        var ref = db.ref(`classMentors/userProfiles`).orderByChild(`user/displayName`).startAt(self.userQuery).endAt(self.userQuery);
+
+        var data = $firebaseArray(ref);
+
+        data.$loaded().then(function (result) {
+            self.foundUsers = result;
+            console.log(self.foundUsers);
+        })
+    };
+
+    this.assignCohortAssistant = function (user) {
+        var asst = {
+            name: user.user.displayName,
+            canEdit: true,
+            canReview: true
+        };
+        var assistantId = user.$id;
+        for(let event in self.cohort.events) {
+            let eventId = self.cohort.events[event];
+            clmDataStore.events.addAssistant(eventId, assistantId, asst);
+        };
+        spfAlert.success('Added assistant.');
+        this.foundUsers = null;
+    };
+
     //
     // function promptPassword() {
     //     if (
@@ -544,7 +576,8 @@ ViewCohortCtrl.$inject = [
     'firebaseApp',
     'spfAuthData',
     'spfNavBarService',
-    'clmDataStore'
+    'clmDataStore',
+    '$firebaseArray'
 ];
 
 /**

--- a/src/classmentors/services.js
+++ b/src/classmentors/services.js
@@ -1047,7 +1047,11 @@ export function clmDataStoreFactory(
         var ref = db.ref(`classMentors/eventTasks/${eventId}/${taskId}`);
         var priority = task.priority;
 
-        return ref.setWithPriority(task, priority);
+        if(priority) {
+          return ref.setWithPriority(task, priority);
+        } else {
+          ref.set(task);
+        }
       },
 
       joinTeam: function(eventId, taskId, teamId, participantId, user) {

--- a/src/classmentors/services.js
+++ b/src/classmentors/services.js
@@ -1050,7 +1050,7 @@ export function clmDataStoreFactory(
         if(priority) {
           return ref.setWithPriority(task, priority);
         } else {
-          ref.set(task);
+          return ref.set(task);
         }
       },
 


### PR DESCRIPTION
Implemented UI for cohort assistants. Querying is still very static. There is no immediately usable 'LIKE' SQL equivalent in Firebase, making comprehensive user querying difficult. You must search for a user's displayName exactly when adding them as a cohort assistant. 

Cohort assistants are default set to canEdit and canReview = true. Again, there is not yet a UI to toggle this.